### PR TITLE
Fix recv loop hanging on NUL-terminated CGMiner responses

### DIFF
--- a/app/exporter.py
+++ b/app/exporter.py
@@ -221,7 +221,13 @@ def query_miner(host: str, port: int, cmd: str, timeout: float = MINER_TIMEOUT) 
                 if total > MAX_RESPONSE_SIZE:
                     raise ValueError(f"Response from {host}:{port} exceeded {MAX_RESPONSE_SIZE} bytes, truncating")
                 chunks.append(data)
-            return b"".join(chunks).decode("ascii", errors="replace")
+                # CGMiner API responses are NUL-terminated; stop reading
+                # once we see \0 so we don't block waiting for the miner
+                # to close the connection (which some firmware never does).
+                if b"\x00" in data:
+                    break
+            raw = b"".join(chunks)
+            return raw.replace(b"\x00", b"").decode("ascii", errors="replace")
     except socket.timeout as e:
         raise socket.timeout(f"Timeout connecting to {host}:{port} after {timeout}s") from e
     except ConnectionRefusedError as e:


### PR DESCRIPTION
## Summary
- CGMiner API responses are NUL-terminated (`\0`), but the recv loop in `query_miner` waited for EOF (empty `recv`). When the miner doesn't close the TCP connection after responding, `recv` blocks until the socket timeout fires — then discards all valid data already received, causing every scrape to appear as a timeout failure.
- The fix breaks the recv loop when a NUL byte is detected, so scrapes complete immediately after the full response arrives instead of hanging for `MINER_TIMEOUT` seconds.

## Test plan
- [ ] Deploy container against a live Avalon miner and verify scrapes complete without delay
- [ ] Confirm `/metrics` endpoint returns valid data immediately after startup
- [ ] Check logs show no spurious timeout warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)