### PR TITLE
feat: add AvalonMiner 1047 support

### DIFF
--- a/AVALONMINER-1047.md
+++ b/AVALONMINER-1047.md
@@ -1,0 +1,33 @@
+# AvalonMiner 1047 support
+
+This note documents the sanitized AvalonMiner 1047 contract used for parser
+coverage. It does not include raw miner payloads, DNA values, MAC addresses,
+pool URLs, account names, worker names, or private timestamps.
+
+Validated target shape:
+
+- Model/product: `AvalonMiner 1047`
+- CGMiner: `4.11.1`
+- CGMiner API: `3.7`
+- API port: `4028`
+- Hash boards: `2`
+- Read-only commands used by the exporter:
+  `version+summary+stats+config+devs+devdetails+pools`
+
+Additional 1047 mappings:
+
+| Source field | Metric | Unit / behavior |
+|---|---|---|
+| `Temp` | `avalon_temp_current_celsius` | Celsius |
+| `Fan2` | `avalon_fan2_rpm` | RPM |
+| `SYSTEMSTATU` | `avalon_system_working` | 1 when the status contains `In Work` |
+| `SYSTEMSTATU` | `avalon_hash_boards` | Parsed from `Hash Board: <n>` |
+| `MHS 30s` | `avalon_hashrate_ghs` | Converted from MH/s to GH/s when `GHSspd` is absent |
+| `MHS 1m` | `avalon_hashrate_1m_ghs` | Converted from MH/s to GH/s |
+| `MHS 5m` | `avalon_hashrate_5m_ghs` | Converted from MH/s to GH/s |
+| `MHS 15m` | `avalon_hashrate_15m_ghs` | Converted from MH/s to GH/s |
+| `PVT_T0`, `PVT_T1` | chip temperature aggregates | Combined across hash boards |
+| `PVT_V0`, `PVT_V1` | chip voltage aggregates | Combined across hash boards, raw values divided by 100 |
+| `MW0`, `MW1` | chip matching-work aggregates | Combined across hash boards |
+
+Power fields remain firmware-defined unless model-specific units are verified.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A lightweight, zero-dependency Prometheus exporter for **Avalon Home-series ASIC
 
 - **Avalon Nano 3S**
 - **Avalon Mini 3**
+- **AvalonMiner 1047**
 - Other Avalon Home-series miners using the CGMiner TCP API
 
 The exporter polls miners over their CGMiner TCP API (default port **4028**) and exposes a Prometheus-compatible `/metrics` endpoint with accurate, low-level miner telemetry suitable for Grafana dashboards and long-term monitoring.
@@ -15,7 +16,7 @@ The exporter polls miners over their CGMiner TCP API (default port **4028**) and
 ## 🚀 Features
 
 ✔ Supports **multiple miners** (comma-separated hostnames/IPs)  
-✔ Automatic detection of **Nano 3S** and **Mini 3** via `version`  
+✔ Automatic detection of **Nano 3S**, **Mini 3**, and **AvalonMiner 1047** via `version`
 ✔ Uses CGMiner API commands combined into a single request:
 
 - `version`
@@ -32,6 +33,8 @@ The exporter polls miners over their CGMiner TCP API (default port **4028**) and
 - Temperatures (inlet, outlet, average, max, target)
 - Fan RPM and duty %
 - Share stats (accepted, rejected, stale)
+- AvalonMiner 1047 second fan, current temperature, hash-board count, and
+  summary hashrate windows
 - Pool performance (per pool index)
 - Work utility
 - Hardware error counters and rates
@@ -41,8 +44,8 @@ The exporter polls miners over their CGMiner TCP API (default port **4028**) and
 
 ✔ Optional extended telemetry:
 
-- Per-chip voltage telemetry (PVT_V0)
-- Per-chip matching-work telemetry (MW0)
+- Per-chip voltage telemetry (PVT_V0/PVT_V1)
+- Per-chip matching-work telemetry (MW0/MW1)
 - Power / board telemetry (MPO / PS)
 - Extended pool/network counters from `stats`
 

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -132,17 +132,24 @@ MINER_METRIC_META: dict[str, tuple[str, str]] = {
     "avalon_lcd_switch":                    ("gauge", "LCD switching enabled (0/1)."),
     # Temperatures
     "avalon_temp_inlet_celsius":            ("gauge", "Inlet/intake temperature in Celsius (may be -273 on some firmware)."),
+    "avalon_temp_current_celsius":          ("gauge", "Current miner temperature in Celsius (Temp)."),
     "avalon_temp_outlet_celsius":           ("gauge", "Outlet/exhaust temperature in Celsius."),
     "avalon_temp_avg_celsius":              ("gauge", "Average ASIC temperature in Celsius."),
     "avalon_temp_max_celsius":              ("gauge", "Maximum observed ASIC temperature in Celsius."),
     "avalon_temp_target_celsius":           ("gauge", "Target temperature used by the control loop in Celsius."),
     # ASIC topology
     "avalon_total_asics":                   ("gauge", "Total number of ASICs present."),
+    "avalon_hash_boards":                   ("gauge", "Number of hash boards reported by firmware."),
+    "avalon_system_working":                ("gauge", "Whether the firmware system status reports active work (0/1)."),
     # Fans
     "avalon_fan1_rpm":                      ("gauge", "Primary fan speed in RPM."),
+    "avalon_fan2_rpm":                      ("gauge", "Secondary fan speed in RPM."),
     "avalon_fan_duty_percent":              ("gauge", "Fan duty cycle percentage."),
     # Hashrate & performance
-    "avalon_hashrate_ghs":                  ("gauge", "Instantaneous hashrate in GH/s."),
+    "avalon_hashrate_ghs":                  ("gauge", "Short-window hashrate in GH/s."),
+    "avalon_hashrate_1m_ghs":               ("gauge", "One-minute hashrate in GH/s from summary MHS 1m."),
+    "avalon_hashrate_5m_ghs":               ("gauge", "Five-minute hashrate in GH/s from summary MHS 5m."),
+    "avalon_hashrate_15m_ghs":              ("gauge", "Fifteen-minute hashrate in GH/s from summary MHS 15m."),
     "avalon_hashrate_moving_ghs":           ("gauge", "Moving/medium-window average hashrate in GH/s."),
     "avalon_hashrate_avg_ghs":              ("gauge", "Longer-term average hashrate in GH/s."),
     "avalon_work_utility":                  ("gauge", "Work utility from stats."),
@@ -173,7 +180,7 @@ MINER_METRIC_META: dict[str, tuple[str, str]] = {
     "avalon_session_pool_stale_percent":    ("gauge", "Session-wide pool stale share percentage."),
     "avalon_work_utility_summary":          ("gauge", "Work utility from summary."),
     # Chip aggregates
-    "avalon_chip_count":                    ("gauge", "Number of chips detected across PVT_T0/PVT_V0/MW0."),
+    "avalon_chip_count":                    ("gauge", "Number of chips detected across PVT_T*/PVT_V*/MW* arrays."),
     "avalon_chip_temp_min_celsius":         ("gauge", "Minimum per-chip temperature in Celsius."),
     "avalon_chip_temp_avg_celsius":         ("gauge", "Average per-chip temperature in Celsius."),
     "avalon_chip_temp_max_celsius":         ("gauge", "Maximum per-chip temperature in Celsius."),
@@ -463,6 +470,36 @@ def bool_numeric(raw_val: str | None) -> float:
         return 1.0
     return 0.0
 
+def parse_summary_mhs_to_ghs(value: str | None) -> float | None:
+    """Parse a CGMiner summary MHS value and convert it to GH/s."""
+    f = parse_float(value)
+    if f is None:
+        return None
+    return f / 1000.0
+
+def parse_system_hash_boards(value: str | None) -> int | None:
+    """Extract hash-board count from SYSTEMSTATU strings such as 'Hash Board: 2'."""
+    if not value:
+        return None
+    m = re.search(r"Hash\s+Board:\s*(\d+)", str(value), flags=re.IGNORECASE)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+def parse_system_working(value: str | None) -> float | None:
+    """Return 1 when SYSTEMSTATU indicates active work, 0 when it indicates no work."""
+    if not value:
+        return None
+    s = str(value).lower()
+    if "in work" in s:
+        return 1.0
+    if "no work" in s or "idle" in s or "stopped" in s:
+        return 0.0
+    return None
+
 def parse_csv_kv(segment: str) -> dict[str, str]:
     """Parse a CSV segment of key=value pairs into a dict. Handles keys with spaces."""
     result: dict[str, str] = {}
@@ -692,6 +729,7 @@ def _parse_miner_metrics(stats0: str, summary_section: str) -> dict[str, float]:
     # Temps (report ITemp as-is, even if -273)
     for key, val in [
         ("avalon_temp_inlet_celsius", bracket.get("ITemp", "N/A")),
+        ("avalon_temp_current_celsius", bracket.get("Temp", "N/A")),
         ("avalon_temp_outlet_celsius", bracket.get("OTemp", "N/A")),
         ("avalon_temp_avg_celsius", bracket.get("TAvg", "N/A")),
         ("avalon_temp_max_celsius", bracket.get("TMax", "N/A")),
@@ -706,23 +744,48 @@ def _parse_miner_metrics(stats0: str, summary_section: str) -> dict[str, float]:
     if total_asics is not None:
         metrics["avalon_total_asics"] = float(total_asics)
 
+    system_status = bracket.get("SYSTEMSTATU", "")
+    hash_boards = parse_system_hash_boards(system_status)
+    if hash_boards is not None:
+        metrics["avalon_hash_boards"] = float(hash_boards)
+    system_working = parse_system_working(system_status)
+    if system_working is not None:
+        metrics["avalon_system_working"] = system_working
+
     # Fans
     f_fan1 = parse_float(bracket.get("Fan1", "N/A"))
     if f_fan1 is not None:
         metrics["avalon_fan1_rpm"] = f_fan1
+    f_fan2 = parse_float(bracket.get("Fan2", "N/A"))
+    if f_fan2 is not None:
+        metrics["avalon_fan2_rpm"] = f_fan2
     f_fanr = parse_float(bracket.get("FanR", "N/A"))
     if f_fanr is not None:
         metrics["avalon_fan_duty_percent"] = f_fanr
 
     # Hashrate & WU
+    hashrate_short = parse_float(bracket.get("GHSspd", "N/A"))
+    if hashrate_short is None:
+        hashrate_short = parse_summary_mhs_to_ghs(summary_kv.get("MHS 30s", "N/A"))
+    if hashrate_short is not None:
+        metrics["avalon_hashrate_ghs"] = hashrate_short
+
     for key, val in [
-        ("avalon_hashrate_ghs", bracket.get("GHSspd", "N/A")),
         ("avalon_hashrate_moving_ghs", bracket.get("GHSmm", "N/A")),
         ("avalon_hashrate_avg_ghs", bracket.get("GHSavg", "N/A")),
         ("avalon_work_utility", bracket.get("WU", "N/A")),
         ("avalon_frequency_mhz", bracket.get("Freq", "N/A")),
     ]:
         f = parse_float(val)
+        if f is not None:
+            metrics[key] = f
+
+    for key, val in [
+        ("avalon_hashrate_1m_ghs", summary_kv.get("MHS 1m", "N/A")),
+        ("avalon_hashrate_5m_ghs", summary_kv.get("MHS 5m", "N/A")),
+        ("avalon_hashrate_15m_ghs", summary_kv.get("MHS 15m", "N/A")),
+    ]:
+        f = parse_summary_mhs_to_ghs(val)
         if f is not None:
             metrics[key] = f
 
@@ -811,14 +874,20 @@ def _parse_chip_metrics(stats0: str) -> tuple[dict[str, float], list[ChipData]]:
     # Pre-parse stats0 for O(1) lookups
     bracket = parse_all_bracket(stats0)
 
-    # Chip temps (PVT_T0), voltages (PVT_V0), chip matching-work telemetry (MW0)
-    chip_t_raw = bracket.get("PVT_T0", "N/A")
-    chip_v_raw = bracket.get("PVT_V0", "N/A")
-    chip_mw_raw = bracket.get("MW0", "N/A")
-    
-    chip_t = parse_int_list(chip_t_raw) if chip_t_raw != "N/A" else []
-    chip_v_ints = parse_int_list(chip_v_raw) if chip_v_raw != "N/A" else []
-    chip_mw = parse_int_list(chip_mw_raw) if chip_mw_raw != "N/A" else []
+    # Chip temps, voltages, and matching-work telemetry. Some Avalon 10-series
+    # miners report one array per hash board, e.g. PVT_T0/PVT_T1.
+    chip_t: list[int] = []
+    chip_v_ints: list[int] = []
+    chip_mw: list[int] = []
+    for key, dest in [
+        ("PVT_T", chip_t),
+        ("PVT_V", chip_v_ints),
+        ("MW", chip_mw),
+    ]:
+        for idx in range(16):
+            raw = bracket.get(f"{key}{idx}", "N/A")
+            if raw != "N/A":
+                dest.extend(parse_int_list(raw))
     
     chip_count = max(len(chip_t), len(chip_v_ints), len(chip_mw))
     if chip_count > 0:

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -496,7 +496,8 @@ def parse_system_working(value: str | None) -> float | None:
     s = str(value).lower()
     if "in work" in s:
         return 1.0
-    if "no work" in s or "idle" in s or "stopped" in s:
+    inactive_states = ("in idle", "in init", "in fault", "no work", "idle", "stopped")
+    if any(status in s for status in inactive_states):
         return 0.0
     return None
 

--- a/tests/test_avalonminer_1047.py
+++ b/tests/test_avalonminer_1047.py
@@ -1,0 +1,80 @@
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "app"))
+
+import exporter  # noqa: E402
+
+
+SUMMARY_1047 = (
+    "CMD=summary|SUMMARY,Elapsed=3600,MHS av=30000000.00,"
+    "MHS 30s=33000000.00,MHS 1m=32000000.00,MHS 5m=31000000.00,"
+    "MHS 15m=30500000.00,Found Blocks=0,Accepted=42,Rejected=1,"
+    "Stale=0,Hardware Errors=7,Work Utility=450.5,Device Hardware%=0.01,"
+    "Device Rejected%=0.02,Pool Rejected%=0.03,Pool Stale%=0.00|"
+)
+
+STATS0_1047 = (
+    "STATS=0,ID=AV1047,Elapsed=3600,MM Count=2,"
+    "MM ID0[Ver[synthetic],DNA[REDACTED],SYSTEMSTATU[Work: In Work, Hash Board: 2],"
+    "Temp[66],TMax[82],TAvg[70],Fan1[5600],Fan2[5700],FanR[88%],"
+    "GHSmm[33300.5],GHSavg[32100.25],WU[450.5],Freq[625],HW[7],DH[0.01%],"
+    "MPO[2220],PVT_T0[60 61 62],PVT_T1[63 64 65],"
+    "PVT_V0[303 304 305],PVT_V1[306 307 308],MW0[1 2 3],MW1[4 5 6]]|"
+)
+
+VERSION_1047 = (
+    "CMD=version|VERSION,CGMiner=4.11.1,API=3.7,MODEL=1047,"
+    "PROD=AvalonMiner 1047,LVERSION=synthetic,DNA=REDACTED,MAC=REDACTED|"
+)
+
+
+class AvalonMiner1047ParsingTest(unittest.TestCase):
+    def test_miner_metrics_parse_1047_summary_and_stats_fields(self):
+        metrics = exporter._parse_miner_metrics(STATS0_1047, SUMMARY_1047)
+
+        self.assertEqual(metrics["avalon_temp_current_celsius"], 66.0)
+        self.assertEqual(metrics["avalon_temp_max_celsius"], 82.0)
+        self.assertEqual(metrics["avalon_temp_avg_celsius"], 70.0)
+        self.assertEqual(metrics["avalon_fan1_rpm"], 5600.0)
+        self.assertEqual(metrics["avalon_fan2_rpm"], 5700.0)
+        self.assertEqual(metrics["avalon_fan_duty_percent"], 88.0)
+        self.assertEqual(metrics["avalon_hash_boards"], 2.0)
+        self.assertEqual(metrics["avalon_system_working"], 1.0)
+
+        self.assertEqual(metrics["avalon_hashrate_ghs"], 33000.0)
+        self.assertEqual(metrics["avalon_hashrate_1m_ghs"], 32000.0)
+        self.assertEqual(metrics["avalon_hashrate_5m_ghs"], 31000.0)
+        self.assertEqual(metrics["avalon_hashrate_15m_ghs"], 30500.0)
+        self.assertEqual(metrics["avalon_hashrate_moving_ghs"], 33300.5)
+        self.assertEqual(metrics["avalon_hashrate_avg_ghs"], 32100.25)
+
+    def test_chip_aggregates_include_second_hash_board_arrays(self):
+        metrics, chips = exporter._parse_chip_metrics(STATS0_1047)
+
+        self.assertEqual(chips, [])
+        self.assertEqual(metrics["avalon_chip_count"], 6.0)
+        self.assertEqual(metrics["avalon_chip_temp_min_celsius"], 60.0)
+        self.assertEqual(metrics["avalon_chip_temp_avg_celsius"], 62.5)
+        self.assertEqual(metrics["avalon_chip_temp_max_celsius"], 65.0)
+        self.assertAlmostEqual(metrics["avalon_chip_voltage_min_volts"], 3.03)
+        self.assertAlmostEqual(metrics["avalon_chip_voltage_avg_volts"], 3.055)
+        self.assertAlmostEqual(metrics["avalon_chip_voltage_max_volts"], 3.08)
+        self.assertEqual(metrics["avalon_chip_matching_work_sum"], 21.0)
+
+    def test_version_info_keeps_1047_model_and_product(self):
+        info = exporter.extract_version_info_from_section(VERSION_1047)
+
+        self.assertEqual(info["model"], "1047")
+        self.assertEqual(info["prod"], "AvalonMiner 1047")
+        self.assertEqual(info["cgminer"], "4.11.1")
+        self.assertEqual(info["api"], "3.7")
+        self.assertEqual(info["dna"], "REDACTED")
+        self.assertEqual(info["mac"], "REDACTED")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_avalonminer_1047.py
+++ b/tests/test_avalonminer_1047.py
@@ -33,6 +33,21 @@ VERSION_1047 = (
 
 
 class AvalonMiner1047ParsingTest(unittest.TestCase):
+    def test_system_working_handles_official_avalon_states(self):
+        cases = {
+            "Work: In Work, Hash Board: 2": 1.0,
+            "Work: In Idle, Hash Board: 2": 0.0,
+            "Work: In Init, Hash Board: 2": 0.0,
+            "Work: In Fault, Hash Board: 2": 0.0,
+        }
+
+        for status, want in cases.items():
+            with self.subTest(status=status):
+                self.assertEqual(exporter.parse_system_working(status), want)
+
+    def test_system_working_preserves_none_for_unknown_status(self):
+        self.assertIsNone(exporter.parse_system_working("Work: In Mystery, Hash Board: 2"))
+
     def test_miner_metrics_parse_1047_summary_and_stats_fields(self):
         metrics = exporter._parse_miner_metrics(STATS0_1047, SUMMARY_1047)
 


### PR DESCRIPTION
## Summary

Adds focused AvalonMiner 1047 parser support without changing the exporter architecture or default high-cardinality behavior.

## Tested contract

- Miner model/product: AvalonMiner 1047
- CGMiner: 4.11.1
- CGMiner API: 3.7
- API port: 4028
- Hash boards: 2
- Exporter command remains read-only: `version+summary+stats+config+devs+devdetails+pools`

## Added or corrected metrics

- `Temp` -> `avalon_temp_current_celsius`
- `Fan2` -> `avalon_fan2_rpm`
- `SYSTEMSTATU` -> `avalon_system_working` and `avalon_hash_boards`
- Summary `MHS 30s` -> `avalon_hashrate_ghs` fallback when `GHSspd` is absent
- Summary `MHS 1m`, `MHS 5m`, `MHS 15m` -> GH/s window metrics
- Board-indexed `PVT_T*`, `PVT_V*`, and `MW*` arrays are combined for chip aggregate metrics, covering two-board 1047 payloads while keeping per-chip metrics disabled by default unless `EXPORT_CHIP_METRICS=true`

Power fields remain firmware-defined unless model-specific units are verified.

## Compatibility

- Preserves existing Nano 3S / Mini 3 parsing paths.
- Keeps existing metric names and only adds metrics or fallback behavior where the previous metric was absent.
- Does not enable chip metrics by default.
- Does not add state-changing CGMiner commands.

## Tests

- Added sanitized `unittest` coverage for AvalonMiner 1047 parser behavior.
- Ran: `python -m unittest discover -s tests -v`
- Ran: `git diff --check`

## Privacy treatment

The test fixture is synthetic/sanitized. It does not include raw live payloads, DNA values, MAC addresses, pool URLs, account names, worker names, private timestamps, or private network details.